### PR TITLE
✨ 버튼 컴포넌트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddang-ddang-ddang",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.2"
@@ -2082,6 +2083,15 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.2"

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,61 @@
+// Button.tsx
+
+import clsx from 'clsx';
+
+// Button 컴포넌트의 props 타입 정의
+type ButtonProps = {
+  children: React.ReactNode;
+  variant?: 'primary' | 'secondary'; // 버튼 스타일 종류
+  size?: 'sm' | 'md' | 'lg'; // 버튼 크기
+  isLoading?: boolean; // 로딩 상태
+} & React.ComponentPropsWithoutRef<'button'>; // 기본 button 속성들 포함
+
+// Button 컴포넌트 정의
+const Button = ({
+  // Button 컴포넌트의 props (디폴트 값 포함)
+  children,
+  variant = 'primary',
+  size = 'md',
+  isLoading = false,
+  ...rest // 나머지 button 속성들 (onClick, disabled 등)
+}: ButtonProps) => {
+  const baseStyles = 'font-bold py-2 px-4 rounded transition-colors flex items-center justify-center';
+
+  const variantStyles = {
+    //primary와 secondary 스타일 정의 -> 와이어프레임 나오면 수정해야 할 것 같습니다.
+    primary: 'bg-yellow-400 hover:bg-blue-700 text-black',
+    secondary: 'bg-yellow-200 hover:bg-gray-700 text-black',
+  };
+
+  const sizeStyles = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg',
+  };
+
+  const finalClassName = clsx(
+    // 클래스네임 조합(base, variant, size, 로딩 상태, 추가 클래스네임)
+    baseStyles,
+    variantStyles[variant],
+    sizeStyles[size],
+    isLoading && 'opacity-50 cursor-not-allowed', 
+    rest.className
+  );
+
+  return (
+    <button {...rest} className={finalClassName} disabled={isLoading || rest.disabled}>
+      {/* 로딩 중이면 스피너 또는 텍스트 표시, 아니면 원래 children 표시 */}
+      {isLoading ? (
+        <>
+          {/* 간단한 로딩 스피너 예시 (Tailwind 애니메이션 사용) */}
+          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+          처리 중...
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -8,6 +8,7 @@ type ButtonProps = {
   variant?: 'primary' | 'secondary'; // 버튼 스타일 종류
   size?: 'sm' | 'md' | 'lg'; // 버튼 크기
   isLoading?: boolean; // 로딩 상태
+  className?: string; // 추가적인 클래스네임(승찬이형 pr 반영)
 } & React.ComponentPropsWithoutRef<'button'>; // 기본 button 속성들 포함
 
 // Button 컴포넌트 정의
@@ -17,14 +18,17 @@ const Button = ({
   variant = 'primary',
   size = 'md',
   isLoading = false,
+  className = '', // className prop의 기본값 설정
   ...rest // 나머지 button 속성들 (onClick, disabled 등)
 }: ButtonProps) => {
-  const baseStyles = 'font-bold py-2 px-4 rounded transition-colors flex items-center justify-center';
+
+  const baseStyles = 'transition-colors flex items-center justify-center'; // 공통 스타일만 남김
 
   const variantStyles = {
-    //primary와 secondary 스타일 정의 -> 와이어프레임 나오면 수정해야 할 것 같습니다.
-    primary: 'bg-yellow-400 hover:bg-blue-700 text-black',
-    secondary: 'bg-yellow-200 hover:bg-gray-700 text-black',
+    // primary와 secondary 스타일 정의 -> 와이어프레임 나오면 그거에 맞게 색상 수정해야 할 것 같습니다.
+    // primary와 secondary에 패딩, 폰트 굵기, 둥근 모서리 스타일 포함 (승찬이형 pr 반영)
+    primary: 'bg-yellow-400 hover:bg-blue-700 text-black font-bold py-2 px-4 rounded',
+    secondary: 'bg-yellow-200 hover:bg-gray-700 text-black font-medium py-1 px-3 rounded-lg',
   };
 
   const sizeStyles = {
@@ -39,7 +43,7 @@ const Button = ({
     variantStyles[variant],
     sizeStyles[size],
     isLoading && 'opacity-50 cursor-not-allowed', 
-    rest.className
+    className
   );
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from '@/App'
-import '@/styles'
+import '@/styles/index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,3 +1,10 @@
+import Button from '@/components/common/Button';
+
 export default function Main() {
-  return <div className="text-yellow-400">Main 페이지입니다.</div>;
+  return (
+  <div>
+    <div className="text-yellow-400">Main 페이지입니다.</div>
+    <Button variant="primary" onClick={() => alert('버튼 클릭!')}>primary 버튼</Button>
+    <Button variant="secondary" onClick={() => alert('버튼 클릭!')}>secondary 버튼</Button>
+  </div>);
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,10 +1,6 @@
-import Button from '@/components/common/Button';
-
 export default function Main() {
   return (
   <div>
     <div className="text-yellow-400">Main 페이지입니다.</div>
-    <Button variant="primary" onClick={() => alert('버튼 클릭!')}>primary 버튼</Button>
-    <Button variant="secondary" onClick={() => alert('버튼 클릭!')}>secondary 버튼</Button>
   </div>);
 }


### PR DESCRIPTION
버튼 컴포넌트 피드백 반영하여 구현했습니다.

## 제목
제목 가이드(권장): ✨ 버튼 컴포넌트 


## 작업 내용
버튼 컴포넌트 구현했습니다.
variant 넣어서 primary랑 secondary 로 선택하면 색깔별로 구분될 수 있게 했습니다.
size prop을 추가하여 버튼 크기를 sm, md, lg로 조절할 수 있습니다.
isLoading prop을 추가하여 로딩 상태를 시각적으로 표시하도록 구현했습니다.
clsx 유틸리티를 활용해 동적으로 클래스 이름을 결합하여 재사용성과 확장성을 높였습니다.

피드백 반영 (25.10.01)
1. Props에 className 추가
2. 패딩 및 볼드 설정 -> 버튼 종류에서 설정


## 스크린샷/증빙(선택)
<img width="1919" height="856" alt="버튼컴포넌트" src="https://github.com/user-attachments/assets/3d336954-9689-4148-a734-1dd36bdacdaa" />
<img width="1919" height="863" alt="버튼컴포넌트_피드백" src="https://github.com/user-attachments/assets/8f63fbd1-a33e-47f3-a0f3-3c0038cf9361" />


## 공유 사항
main에서 버튼 제거 했습니다.
처음에 npm run dev가 안되서 main.tsx에서 import '@/styles 를 import '@/styles/index.css'로 수정했습니다