### PR TITLE
✨ Textarea 컴포넌트 구현

### DIFF
--- a/src/components/common/textarea.tsx
+++ b/src/components/common/textarea.tsx
@@ -1,0 +1,97 @@
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  forwardRef,
+  ChangeEvent,
+} from "react";
+
+export interface TextareaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "rows"> {
+  /** 최소 보이는 줄 수(높이 기준). 기본값 1 */
+  minRows?: number;
+  /** 최대 보이는 줄 수(높이 상한). 지정하지 않으면 제한 없음 */
+  maxRows?: number;
+}
+
+/**
+ * 내용 길이에 따라 자동으로 높이가 변하는 Textarea.
+ * 높이는 minRows ~ maxRows 범위 안에서만 늘어나거나 줄어듭니다.
+ */
+export const Textarea = forwardRef<
+  HTMLTextAreaElement,
+  TextareaProps
+>(function Textarea(
+  { minRows = 1, 
+    maxRows, 
+    onChange, 
+    className = "w-full rounded-md border border-gray-300 p-3 focus:outline-none focus:ring-2 focus:ring-blue-500", 
+    ...props },
+  ref
+) {
+  const innerRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // 전달받은 ref를 실제 DOM 노드로 연결
+  React.useImperativeHandle(ref, () => innerRef.current as HTMLTextAreaElement);
+
+  const resize = useCallback(() => {
+    const el = innerRef.current;
+    if (!el) return;
+
+    const computed = window.getComputedStyle(el);
+    const lineHeight = parseFloat(computed.lineHeight || "0");
+    const paddingY =
+      parseFloat(computed.paddingTop || "0") +
+      parseFloat(computed.paddingBottom || "0");
+    const borderY =
+      parseFloat(computed.borderTopWidth || "0") +
+      parseFloat(computed.borderBottomWidth || "0");
+
+    const min = Math.max(1, Math.floor(minRows));
+    const max =
+      typeof maxRows === "number" && maxRows > 0
+        ? Math.max(min, Math.floor(maxRows))
+        : Number.POSITIVE_INFINITY;
+
+    const minHeight = min * lineHeight + paddingY + borderY;
+    const maxHeight =
+      max === Number.POSITIVE_INFINITY
+        ? Number.POSITIVE_INFINITY
+        : max * lineHeight + paddingY + borderY;
+
+    // scrollHeight를 정확히 측정하기 위해 높이를 초기화
+    el.style.height = "auto";
+
+    const natural = el.scrollHeight;
+    const nextHeight = Math.min(
+      Math.max(natural, minHeight),
+      maxHeight
+    );
+
+    el.style.height = `${nextHeight}px`;
+    el.style.overflowY = natural > maxHeight ? "auto" : "hidden";
+  }, [minRows, maxRows]);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange?.(e);
+    // 입력 변경 직후 내용에 맞게 즉시 리사이즈
+    resize();
+  };
+
+  // 마운트 시, 그리고 외부에서 value가 변경될 때마다 리사이즈
+  useLayoutEffect(() => {
+    resize();
+  }, [resize, props.value]);
+
+  return (
+    <textarea
+      {...props}
+      ref={innerRef}
+      rows={minRows}
+      onChange={handleChange}
+      className={`resize-none overflow-hidden ${className ?? ""}`}
+    />
+  );
+});
+
+export default Textarea;

--- a/src/components/common/textarea.tsx
+++ b/src/components/common/textarea.tsx
@@ -5,6 +5,7 @@ import React, {
   forwardRef,
   ChangeEvent,
 } from "react";
+import clsx from "clsx";
 
 export interface TextareaProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "rows"> {
@@ -22,11 +23,7 @@ export const Textarea = forwardRef<
   HTMLTextAreaElement,
   TextareaProps
 >(function Textarea(
-  { minRows = 1, 
-    maxRows, 
-    onChange, 
-    className = "w-full rounded-md border border-gray-300 p-3 focus:outline-none focus:ring-2 focus:ring-blue-500", 
-    ...props },
+  { minRows = 1, maxRows, onChange, className, ...props },
   ref
 ) {
   const innerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -89,7 +86,14 @@ export const Textarea = forwardRef<
       ref={innerRef}
       rows={minRows}
       onChange={handleChange}
-      className={`resize-none overflow-hidden ${className ?? ""}`}
+      className={clsx(
+        // 항상 적용될 기본 동작
+        "resize-none overflow-hidden",
+        // 기본 스타일 (사용자 지정 className이 있더라도 합쳐짐)
+        "w-full rounded-md border border-gray-300 p-3 focus:outline-none focus:ring-2 focus:ring-blue-500",
+        // 사용자 지정 클래스는 마지막에 두어 Tailwind 우선순위상 덮어쓰기가 가능하게 함
+        className
+      )}
     />
   );
 });

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,6 +1,55 @@
+import Textarea from "@/components/common/textarea";
+import { useState } from "react";
+
 export default function Main() {
+  const [controlledValue, setControlledValue] = useState("");
+
   return (
-  <div>
-    <div className="text-yellow-400">Main 페이지입니다.</div>
-  </div>);
+    <div className="mx-auto max-w-3xl p-6 space-y-8">
+      <h1 className="text-2xl font-semibold">Textarea 데모</h1>
+
+      {/* 기본: minRows=2, maxRows=6 (언컨트롤드) */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">기본 (minRows=3, maxRows=6)</h2>
+        <Textarea
+          minRows={3}
+          maxRows={6}
+          placeholder="여기에 입력해보세요"
+          defaultValue={"기본 예시입니다.\n줄을 늘려보세요."}
+        />
+      </section>
+
+      {/* 무제한 확장: maxRows 미지정 */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">무제한 확장 (maxRows 없음)</h2>
+        <Textarea
+          minRows={1}
+          placeholder="길게 입력해도 계속 늘어납니다"
+        />
+      </section>
+
+      {/* 작은 상한선: 스크롤 생김 */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">작은 상한선 (minRows=1, maxRows=3)</h2>
+        <Textarea
+          minRows={1}
+          maxRows={3}
+          placeholder="3줄까지만 늘어나고, 넘치면 스크롤됩니다"
+        />
+      </section>
+
+      {/* 컨트롤드: 글자수 카운터 */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">컨트롤드 + 글자수</h2>
+        <Textarea
+          minRows={2}
+          maxRows={8}
+          value={controlledValue}
+          onChange={(e) => setControlledValue(e.target.value)}
+          placeholder="상태로 제어되는 텍스트에리아"
+        />
+        <div className="text-sm text-gray-500">글자수: {controlledValue.length}</div>
+      </section>
+    </div>
+  );
 }


### PR DESCRIPTION
## 제목
<!--
제목 가이드(권장): [이모지] 제목 
예) ✨ 재판 페이지 생성
-->
✨ Textarea 컴포넌트 구현
## 작업 내용
<!-- 작업 목적과 배경을 3~5줄로 간단히 설명하세요. -->
글의 길이에 따라 자동으로 늘어나는 텍스트에리아 컴포넌트를 구현했습니다
- 최소 높이(픽셀이 아닌 몇 줄)를 지정하면 해당 줄을 최소 높이로 
- 최대 높이(픽셀이 아닌 몇 줄)만큼 늘어납니다.
- classname을 props로 받아 커스텀이 가능합니다
- 폰트 사이즈에 늘어날듯(아마?)
- 기본 디자인은 디자인이 안나와 프리스타일
## 스크린샷/증빙(선택)
<!-- 페이지, 화면, 로그, API 응답 등 -->
<img width="908" height="690" alt="image" src="https://github.com/user-attachments/assets/d1c40ab8-9cad-4d43-8015-492d39d5b669" />


https://github.com/user-attachments/assets/9d1d156c-50f9-4de3-a1b5-aba2835c9561

## 공유 사항
사용 방법
```
<Textarea
    minRows={2} // 최소 높이(줄)
    maxRows={8} // 최대 높이(줄)
    value={controlledValue} // 텍스트에리아에 보이는 벨류
    onChange={(e) => setControlledValue(e.target.value)}  // state 변화(글 내용 변화)
    classname=''  // 추가 스타일
    placeholder="상태로 제어되는 텍스트에리아"
  />
```